### PR TITLE
Changing to POSIX compliant sed expression

### DIFF
--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -33,7 +33,7 @@ folder_name=$(basename "$current_directory")
 package_name=$(ask_question "Package name" "$folder_name")
 
 package_description=$(ask_question "Package description" "")
-class_name=$(echo "$package_name" | sed 's/[-_]/ /g' | awk '{for(j=1;j<=NF;j++){ $j=toupper(substr($j,1,1)) substr($j,2) }}1' | sed 's/\s//g')
+class_name=$(echo "$package_name" | sed 's/[-_]/ /g' | awk '{for(j=1;j<=NF;j++){ $j=toupper(substr($j,1,1)) substr($j,2) }}1' | sed 's/[[:space:]]//g')
 
 vendor_name_unsantized=$(ask_question "Vendor name" "spatie")
 


### PR DESCRIPTION
The \s doesn't work for some implementations of sed.

On mac, using \s removes 's' from the class name and keep spaces.

Changing to the POSIX compliant value [[:space:]] should fix it for all.